### PR TITLE
Remove unused link

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -366,8 +366,6 @@ services:
         - ./laravel-echo-server/laravel-echo-server.json:/app/laravel-echo-server.json:ro
       ports:
         - "${LARAVEL_ECHO_SERVER_PORT}:6001"
-      links:
-        - redis
       networks:
         - frontend
         - backend


### PR DESCRIPTION
## Summary
- drop `links` from `laravel-echo-server` service

## Testing
- `docker-compose config` *(fails: docker-compose not installed)*

------
https://chatgpt.com/codex/tasks/task_e_683ff602c59c8321a5971b90c3d5a884