### PR TITLE
Add shared .dockerignore for all build contexts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Ignore git repository
+.git
+.git/**
+
+# Ignore logs
+logs
+**/logs
+*.log
+**/*.log
+
+# Ignore temporary files
+tmp
+temp
+.cache
+*.swp
+*~
+
+# Ignore tests and documentation
+tests
+**/tests
+docs
+**/docs
+
+# Ignore system files
+.DS_Store

--- a/docker/adminer/.dockerignore
+++ b/docker/adminer/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/docker/apache2/.dockerignore
+++ b/docker/apache2/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/docker/aws/.dockerignore
+++ b/docker/aws/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/docker/certbot/.dockerignore
+++ b/docker/certbot/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/docker/elasticsearch/.dockerignore
+++ b/docker/elasticsearch/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/docker/jenkins/.dockerignore
+++ b/docker/jenkins/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/docker/laravel-echo-server/.dockerignore
+++ b/docker/laravel-echo-server/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/docker/maildev/.dockerignore
+++ b/docker/maildev/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/docker/mailhog/.dockerignore
+++ b/docker/mailhog/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/docker/mariadb/.dockerignore
+++ b/docker/mariadb/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/docker/memcached/.dockerignore
+++ b/docker/memcached/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/docker/mysql/.dockerignore
+++ b/docker/mysql/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/docker/nginx/.dockerignore
+++ b/docker/nginx/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/docker/php-fpm/.dockerignore
+++ b/docker/php-fpm/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/docker/php-worker/.dockerignore
+++ b/docker/php-worker/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/docker/phpmyadmin/.dockerignore
+++ b/docker/phpmyadmin/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/docker/postgres/.dockerignore
+++ b/docker/postgres/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/docker/redis/.dockerignore
+++ b/docker/redis/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore

--- a/docker/workspace/.dockerignore
+++ b/docker/workspace/.dockerignore
@@ -1,0 +1,1 @@
+../../.dockerignore


### PR DESCRIPTION
## Summary
- add a repository level `.dockerignore`
- link `.dockerignore` into all Docker build contexts

## Testing
- `docker compose config` *(fails: `docker: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683ff60f8e5483219333cedfdeb7a137