### PR TITLE
Replace deprecated Apache base image

### DIFF
--- a/docker/apache2/Dockerfile
+++ b/docker/apache2/Dockerfile
@@ -1,4 +1,4 @@
-FROM webdevops/apache:ubuntu-16.04
+FROM ubuntu:22.04
 
 LABEL maintainer="David M. Ramos <DavidMRGaona@gmail.com>"
 
@@ -13,12 +13,19 @@ ENV WEB_DOCUMENT_ROOT=${DOCUMENT_ROOT}
 
 ENV WEB_PHP_TIMEOUT=${PHP_UPSTREAM_TIMEOUT}
 
+RUN apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y apache2 \
+    && rm -rf /var/lib/apt/lists/* \
+    && rm /etc/apache2/sites-enabled/000-default.conf \
+    && a2enmod rewrite proxy proxy_fcgi \
+    && printf '<FilesMatch \\.php$>\n\tSetHandler "proxy:fcgi://%s"\n</FilesMatch>\n' "$WEB_PHP_SOCKET" > /etc/apache2/conf-available/php-fpm.conf \
+    && a2enconf php-fpm
+
 EXPOSE 80 443
 
 WORKDIR /var/www/
 
 COPY vhost.conf /etc/apache2/sites-enabled/vhost.conf
+COPY sites/ /etc/apache2/sites-available/
 
-ENTRYPOINT ["/opt/docker/bin/entrypoint.sh"]
-
-CMD ["supervisord"]
+CMD ["apachectl", "-D", "FOREGROUND"]


### PR DESCRIPTION
## Summary
- move Apache build to `ubuntu:22.04`
- install Apache and configure PHP-FPM proxy
- keep same build arguments
- run Apache in foreground

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ff5e850e88321aa13e7174285f067