### PR TITLE
Pin service image versions

### DIFF
--- a/docker/certbot/Dockerfile
+++ b/docker/certbot/Dockerfile
@@ -1,4 +1,5 @@
-FROM phusion/baseimage:latest
+ARG CERTBOT_BASE_IMAGE_VERSION=0.12
+FROM phusion/baseimage:${CERTBOT_BASE_IMAGE_VERSION}
 
 LABEL maintainer="David M. Ramos <DavidMRGaona@gmail.com>"
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -206,7 +206,10 @@ services:
 
 ### MariaDB ##############################################
     mariadb:
-      build: ./mariadb
+      build:
+        context: ./mariadb
+        args:
+          - MARIADB_VERSION=${MARIADB_VERSION}
       volumes:
         - ${DATA_PATH_HOST}/mariadb:/var/lib/mysql
         - ${MARIADB_ENTRYPOINT_INITDB}:/docker-entrypoint-initdb.d
@@ -236,7 +239,10 @@ services:
 
 ### Redis ################################################
     redis:
-      build: ./redis
+      build:
+        context: ./redis
+        args:
+          - REDIS_VERSION=${REDIS_VERSION}
       volumes:
         - ${DATA_PATH_HOST}/redis:/data
       ports:
@@ -246,7 +252,10 @@ services:
 
 ### Memcached ############################################
     memcached:
-      build: ./memcached
+      build:
+        context: ./memcached
+        args:
+          - MEMCACHED_VERSION=${MEMCACHED_VERSION}
       volumes:
         - ${DATA_PATH_HOST}/memcached:/var/lib/memcached
       ports:
@@ -258,7 +267,10 @@ services:
 
 ### phpMyAdmin ###########################################
     phpmyadmin:
-      build: ./phpmyadmin
+      build:
+        context: ./phpmyadmin
+        args:
+          - PHPMYADMIN_VERSION=${PHPMYADMIN_VERSION}
       environment:
         - PMA_ARBITRARY=1
         - MYSQL_USER=${PMA_USER}
@@ -313,6 +325,8 @@ services:
     certbot:
       build:
         context: ./certbot
+        args:
+          - CERTBOT_BASE_IMAGE_VERSION=${CERTBOT_BASE_IMAGE_VERSION}
       volumes:
         - ./data/certbot/certs/:/var/certs
         - ./certbot/letsencrypt/:${APP_CODE_PATH_CONTAINER}/letsencrypt

--- a/docker/env-example
+++ b/docker/env-example
@@ -175,10 +175,12 @@ MYSQL_ENTRYPOINT_INITDB=./mysql/docker-entrypoint-initdb.d
 
 ### REDIS #################################################
 
+REDIS_VERSION=6.2
 REDIS_PORT=6379
 
 ### MARIADB ###############################################
 
+MARIADB_VERSION=10.5
 MARIADB_DATABASE=default
 MARIADB_USER=default
 MARIADB_PASSWORD=secret
@@ -200,6 +202,7 @@ ELASTICSEARCH_HOST_TRANSPORT_PORT=9300
 
 ### MEMCACHED #############################################
 
+MEMCACHED_VERSION=1.6
 MEMCACHED_HOST_PORT=11211
 
 ### ADMINER ###############################################
@@ -209,6 +212,7 @@ ADM_INSTALL_MSSQL=false
 
 ### PHP MY ADMIN ##########################################
 
+PHPMYADMIN_VERSION=5.2
 # Accepted values: mariadb - mysql
 
 PMA_DB_ENGINE=mysql
@@ -230,6 +234,10 @@ MAILDEV_SMTP_PORT=25
 JENKINS_HOST_HTTP_PORT=8090
 JENKINS_HOST_SLAVE_AGENT_PORT=50000
 JENKINS_HOME=./jenkins/jenkins_home
+
+### CERTBOT ###############################################
+
+CERTBOT_BASE_IMAGE_VERSION=0.12
 
 ### LARAVEL ECHO SERVER ###################################
 

--- a/docker/mariadb/Dockerfile
+++ b/docker/mariadb/Dockerfile
@@ -1,4 +1,5 @@
-FROM mariadb:latest
+ARG MARIADB_VERSION=10.5
+FROM mariadb:${MARIADB_VERSION}
 
 LABEL maintainer="David M. Ramos <DavidMRGaona@gmail.com>"
 

--- a/docker/memcached/Dockerfile
+++ b/docker/memcached/Dockerfile
@@ -1,4 +1,5 @@
-FROM memcached:latest
+ARG MEMCACHED_VERSION=1.6
+FROM memcached:${MEMCACHED_VERSION}
 
 LABEL maintainer="David M. Ramos <DavidMRGaona@gmail.com>"
 

--- a/docker/phpmyadmin/Dockerfile
+++ b/docker/phpmyadmin/Dockerfile
@@ -1,4 +1,5 @@
-FROM phpmyadmin/phpmyadmin
+ARG PHPMYADMIN_VERSION=5.2
+FROM phpmyadmin/phpmyadmin:${PHPMYADMIN_VERSION}
 
 LABEL maintainer="David M. Ramos <DavidMRGaona@gmail.com>"
 

--- a/docker/redis/Dockerfile
+++ b/docker/redis/Dockerfile
@@ -1,4 +1,5 @@
-FROM redis:latest
+ARG REDIS_VERSION=6.2
+FROM redis:${REDIS_VERSION}
 
 LABEL maintainer="David M. Ramos <DavidMRGaona@gmail.com>"
 


### PR DESCRIPTION
## Summary
- pin image versions for Redis, Memcached, phpMyAdmin, MariaDB, and Certbot
- allow passing versions via docker-compose arguments
- document recommended versions in `env-example`

## Testing
- `docker-compose -f docker/docker-compose.yml config` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff60af30883218b0ec8acbf75f2c8